### PR TITLE
84 additional fields on user reg

### DIFF
--- a/config/core.entity_form_display.user.user.default.yml
+++ b/config/core.entity_form_display.user.user.default.yml
@@ -4,10 +4,15 @@ status: true
 dependencies:
   config:
     - field.field.user.user.field_drupal_org_username
+    - field.field.user.user.field_first_name
+    - field.field.user.user.field_interests
+    - field.field.user.user.field_last_name
     - field.field.user.user.field_newsletter
+    - field.field.user.user.field_organization
     - field.field.user.user.field_volunteer
   module:
     - mailchimp_lists
+    - path
     - user
 _core:
   default_config_hash: LLAieeozVsoZDb-2PbFxRJpQqnKmpR7-4OoRJnduz-U
@@ -21,25 +26,59 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_drupal_org_username:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_first_name:
     weight: 1
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
-  field_newsletter:
+  field_interests:
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: 'Separate multiple interests with commas'
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+  field_last_name:
     weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_newsletter:
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: mailchimp_lists_select
+  field_organization:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
   field_volunteer:
-    weight: 3
+    weight: 7
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+  path:
+    type: path
+    weight: 9
+    settings: {  }
+    third_party_settings: {  }
   timezone:
-    weight: 4
+    weight: 8
     settings: {  }
     third_party_settings: {  }
 hidden:

--- a/config/core.entity_view_display.user.user.default.yml
+++ b/config/core.entity_view_display.user.user.default.yml
@@ -4,7 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.user.user.field_drupal_org_username
+    - field.field.user.user.field_first_name
+    - field.field.user.user.field_interests
+    - field.field.user.user.field_last_name
     - field.field.user.user.field_newsletter
+    - field.field.user.user.field_organization
     - field.field.user.user.field_volunteer
   module:
     - mailchimp_lists
@@ -23,15 +27,43 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
-  field_newsletter:
+  field_first_name:
     weight: 2
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_interests:
+    weight: 5
+    label: inline
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_last_name:
+    weight: 3
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_newsletter:
+    weight: 6
     label: inline
     settings:
       show_interest_groups: false
     third_party_settings: {  }
     type: mailchimp_lists_subscribe_default
+  field_organization:
+    weight: 4
+    label: inline
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
   field_volunteer:
-    weight: 3
+    weight: 7
     label: inline
     settings:
       format: yes-no

--- a/config/field.field.user.user.field_first_name.yml
+++ b/config/field.field.user.user.field_first_name.yml
@@ -1,0 +1,20 @@
+uuid: 18301b9b-414a-4df3-97d9-fb752de6edd9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_first_name
+  module:
+    - user
+id: user.user.field_first_name
+field_name: field_first_name
+entity_type: user
+bundle: user
+label: 'First name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.user.user.field_interests.yml
+++ b/config/field.field.user.user.field_interests.yml
@@ -1,0 +1,29 @@
+uuid: 2a3b503d-bbc2-467c-91de-6f02647cb3d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_interests
+    - taxonomy.vocabulary.interests
+  module:
+    - user
+id: user.user.field_interests
+field_name: field_interests
+entity_type: user
+bundle: user
+label: Interests
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      interests: interests
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.user.user.field_last_name.yml
+++ b/config/field.field.user.user.field_last_name.yml
@@ -1,0 +1,20 @@
+uuid: dcf8926e-a59e-4b93-a8c2-1abc82d25e7b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_last_name
+  module:
+    - user
+id: user.user.field_last_name
+field_name: field_last_name
+entity_type: user
+bundle: user
+label: 'Last name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.user.user.field_organization.yml
+++ b/config/field.field.user.user.field_organization.yml
@@ -1,0 +1,20 @@
+uuid: 585369a2-9df9-4efb-80bc-6378cde48cc5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_organization
+  module:
+    - user
+id: user.user.field_organization
+field_name: field_organization
+entity_type: user
+bundle: user
+label: Organization
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.user.field_first_name.yml
+++ b/config/field.storage.user.field_first_name.yml
@@ -1,0 +1,21 @@
+uuid: 462554ce-8a9c-4190-afcb-4379714c4fe1
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_first_name
+field_name: field_first_name
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.user.field_interests.yml
+++ b/config/field.storage.user.field_interests.yml
@@ -1,0 +1,20 @@
+uuid: 15457510-4193-4604-893d-bf86c2c3d646
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+    - user
+id: user.field_interests
+field_name: field_interests
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.user.field_last_name.yml
+++ b/config/field.storage.user.field_last_name.yml
@@ -1,0 +1,21 @@
+uuid: 73258a3d-8d3d-44f9-ac3e-5f47865d067b
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_last_name
+field_name: field_last_name
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.user.field_organization.yml
+++ b/config/field.storage.user.field_organization.yml
@@ -1,0 +1,21 @@
+uuid: 4f21c66d-4156-47dc-8540-731653825a43
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.field_organization
+field_name: field_organization
+entity_type: user
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/system.date.yml
+++ b/config/system.date.yml
@@ -2,7 +2,7 @@ country:
   default: ''
 first_day: 0
 timezone:
-  default: UTC
+  default: America/Los_Angeles
   user:
     configurable: true
     warn: false

--- a/config/taxonomy.vocabulary.interests.yml
+++ b/config/taxonomy.vocabulary.interests.yml
@@ -1,0 +1,9 @@
+uuid: e9964f45-ee62-4905-9e65-20c7658f10a1
+langcode: en
+status: true
+dependencies: {  }
+name: Interests
+vid: interests
+description: ''
+hierarchy: 0
+weight: 0


### PR DESCRIPTION
This fields as spec'ed in https://github.com/badcamp/badcamp-2017-Sprint-Planning/issues/84 have been added to the user registration (I have left anon registration disabled).

I also wanted to add sync between First Name and Last Names with the mailchimp list, as it does have those fields by default. Potentially also the Interests taxonomy as mailchimp seems to have a field for that in our list (was going to check further). However, the new mailchimp API key (the one Carson had regenerated after the first one had been in the repo) is no longer working, so I was unable to do this. Perhaps hand this back to me with a D.M. of the new-new API key and I can add that sync in, or ticket separately.
