### PR TITLE
Adding Profile Value to Core Extension Config

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -63,3 +63,4 @@ theme:
   badcamp2017: 0
 _core:
   default_config_hash: m2GVq11UAOVuNgj8x0t5fMOPujpvQQ_zxLoaly1BMEU
+  profile: standard


### PR DESCRIPTION
There was an issue with the core extension profile value. Trying to fix it with this commit.