### PR TITLE
Update profile layout

### DIFF
--- a/web/themes/custom/badcamp2017/templates/user/user.html.twig
+++ b/web/themes/custom/badcamp2017/templates/user/user.html.twig
@@ -19,15 +19,13 @@
 <article{{ attributes }}>
   {% if content %}
     <div class="row align-center">
-      <div class="columns">
+      <div class="columns small-12 medium-4 large-3">
         <div class="thumbnail">
-          {{ content.field_profile_photo }}
+            {{ content.field_profile_photo }}
         </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="columns">
-        {{ content|without('field_profile_photo') }}
+      <div class="columns small-12 medium-8 large-9">
+          {{ content|without('field_profile_photo') }}
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
On mobile, everything is stacked vertically.
On tablet+ the image appears on the left, everything else goes on the right.

The original issue mentioned using the foundation media object for this. Imo the media object tends to cause more problems than it solves, and I've always had better luck just using the ZF grid to control the layout. That's what I ended up going with here.