### PR TITLE
#71: Adding fields for the links and files with custom permissions fo…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "drupal/entity_reference_exposed_filters": "^1.0@alpha",
     "drupal/chosen": "^2.4",
     "drupal/flag": "^4.0@alpha",
-    "drupal/empty_fields": "^1.0@alpha"
+    "drupal/empty_fields": "^1.0@alpha",
+    "drupal/masquerade": "^2.0@beta"
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "41e07ef769ffed5807fa40d30320d3b9",
+    "content-hash": "b264ce144a821297d87ca6afa114556d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3685,6 +3685,73 @@
             "homepage": "https://www.drupal.org/project/mailsystem",
             "support": {
                 "source": "http://cgit.drupalcode.org/mailsystem"
+            }
+        },
+        {
+            "name": "drupal/masquerade",
+            "version": "2.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/masquerade",
+                "reference": "8.x-2.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/masquerade-8.x-2.0-beta1.zip",
+                "reference": "8.x-2.0-beta1",
+                "shasum": "d8071c2b01db9a3cc5d5bc8ecd570276e12840d4"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.0-beta1",
+                    "datestamp": "1481184923",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Gurpartap Singh",
+                    "homepage": "https://www.drupal.org/user/41470"
+                },
+                {
+                    "name": "andypost",
+                    "homepage": "https://www.drupal.org/user/118908"
+                },
+                {
+                    "name": "deekayen",
+                    "homepage": "https://www.drupal.org/user/972"
+                },
+                {
+                    "name": "deviantintegral",
+                    "homepage": "https://www.drupal.org/user/71291"
+                },
+                {
+                    "name": "shrop",
+                    "homepage": "https://www.drupal.org/user/14767"
+                },
+                {
+                    "name": "sun",
+                    "homepage": "https://www.drupal.org/user/54136"
+                }
+            ],
+            "description": "Allows privileged users to masquerade as another user.",
+            "homepage": "https://www.drupal.org/project/masquerade",
+            "support": {
+                "source": "http://cgit.drupalcode.org/masquerade"
             }
         },
         {
@@ -10007,7 +10074,8 @@
         "drupal/webform": 10,
         "drupal/entity_reference_exposed_filters": 15,
         "drupal/flag": 15,
-        "drupal/empty_fields": 15
+        "drupal/empty_fields": 15,
+        "drupal/masquerade": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/config/core.entity_form_display.node.training.default.yml
+++ b/config/core.entity_form_display.node.training.default.yml
@@ -11,11 +11,15 @@ dependencies:
     - field.field.node.training.field_payment_info
     - field.field.node.training.field_session_skill_level
     - field.field.node.training.field_trainer
+    - field.field.node.training.field_training_files
+    - field.field.node.training.field_training_links
     - node.type.training
   module:
     - badcamp_stripe_payment
     - comment
     - datetime_range
+    - file
+    - link
     - path
     - text
 id: node.training.default
@@ -24,14 +28,14 @@ bundle: training
 mode: default
 content:
   comment:
-    weight: 12
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -45,19 +49,19 @@ content:
     type: text_textarea_with_summary
     region: content
   field_event_date_and_time:
-    weight: 4
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: daterange_default
     region: content
   field_event_sponsors:
-    weight: 6
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_event_venue:
-    weight: 5
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -70,13 +74,13 @@ content:
     type: stripe_payment
     region: content
   field_payment_info:
-    weight: 26
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: stripe_payment
     region: content
   field_session_skill_level:
-    weight: 3
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -89,9 +93,24 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  field_training_files:
+    weight: 4
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  field_training_links:
+    weight: 3
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
   path:
     type: path
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -99,14 +118,14 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 11
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 12
     region: content
     third_party_settings: {  }
   title:
@@ -119,7 +138,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 9
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/core.entity_view_display.node.training.default.yml
+++ b/config/core.entity_view_display.node.training.default.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_display.comment.comment.default
     - field.field.node.training.comment
     - field.field.node.training.field_description
     - field.field.node.training.field_event_date_and_time
@@ -12,11 +11,15 @@ dependencies:
     - field.field.node.training.field_payment_info
     - field.field.node.training.field_session_skill_level
     - field.field.node.training.field_trainer
+    - field.field.node.training.field_training_files
+    - field.field.node.training.field_training_links
     - node.type.training
   module:
     - badcamp_stripe_payment
-    - comment
     - datetime_range
+    - empty_fields
+    - file
+    - link
     - text
     - user
 id: node.training.default
@@ -24,15 +27,6 @@ targetEntityType: node
 bundle: training
 mode: default
 content:
-  comment:
-    weight: 8
-    label: above
-    settings:
-      view_mode: default
-      pager_id: 0
-    third_party_settings: {  }
-    type: comment_default
-    region: content
   field_description:
     weight: 4
     label: hidden
@@ -51,7 +45,7 @@ content:
     type: daterange_default
     region: content
   field_event_sponsors:
-    weight: 5
+    weight: 7
     label: hidden
     settings:
       view_mode: image_only
@@ -68,7 +62,7 @@ content:
     type: entity_reference_label
     region: content
   field_payment_info:
-    weight: 6
+    weight: 8
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -90,10 +84,29 @@ content:
     third_party_settings: {  }
     type: string
     region: content
-  links:
-    weight: 7
+  field_training_files:
+    type: file_default
+    weight: 6
     region: content
+    label: above
     settings: {  }
     third_party_settings: {  }
+  field_training_links:
+    type: link
+    weight: 5
+    region: content
+    label: above
+    settings:
+      trim_length: 80
+      rel: nofollow
+      url_only: false
+      url_plain: false
+      target: '0'
+    third_party_settings:
+      empty_fields:
+        handler: ''
+        empty_text: ''
 hidden:
+  comment: true
   flag_add_to_schedule: true
+  links: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -59,6 +59,7 @@ module:
   mailchimp_lists: 0
   mailchimp_signup: 0
   mailsystem: 0
+  masquerade: 0
   menu_ui: 0
   node: 0
   options: 0

--- a/config/field.field.node.training.field_training_files.yml
+++ b/config/field.field.node.training.field_training_files.yml
@@ -1,0 +1,27 @@
+uuid: 1e44c2c1-09c3-4e16-acc3-d8a514785015
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_files
+    - node.type.training
+  module:
+    - file
+id: node.training.field_training_files
+field_name: field_training_files
+entity_type: node
+bundle: training
+label: Files
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: training_files
+  file_extensions: 'txt pdf doc xls docx xlsx csv jpg gif png'
+  max_filesize: '32 MB'
+  description_field: true
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/field.field.node.training.field_training_links.yml
+++ b/config/field.field.node.training.field_training_links.yml
@@ -1,0 +1,23 @@
+uuid: 2cc75b61-0b1f-4d68-a158-5d9c9ae0bb5c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_training_links
+    - node.type.training
+  module:
+    - link
+id: node.training.field_training_links
+field_name: field_training_links
+entity_type: node
+bundle: training
+label: Links
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/field.storage.node.field_training_files.yml
+++ b/config/field.storage.node.field_training_files.yml
@@ -1,23 +1,26 @@
-uuid: 47fe7fd9-2dd8-4797-aa46-3477eee11854
+uuid: 1dce01bb-d53f-439c-8bac-298b1d6d0b8d
 langcode: en
 status: true
 dependencies:
   module:
-    - datetime_range
     - field_permissions
+    - file
     - node
 third_party_settings:
   field_permissions:
     permission_type: custom
-id: node.field_event_date_and_time
-field_name: field_event_date_and_time
+id: node.field_training_files
+field_name: field_training_files
 entity_type: node
-type: daterange
+type: file
 settings:
-  datetime_type: datetime
-module: datetime_range
+  display_field: false
+  display_default: false
+  uri_scheme: private
+  target_type: file
+module: file
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/field.storage.node.field_training_links.yml
+++ b/config/field.storage.node.field_training_links.yml
@@ -1,23 +1,22 @@
-uuid: 47fe7fd9-2dd8-4797-aa46-3477eee11854
+uuid: 1bdc4dcc-1ad8-464e-8123-12e43fe594e4
 langcode: en
 status: true
 dependencies:
   module:
-    - datetime_range
     - field_permissions
+    - link
     - node
 third_party_settings:
   field_permissions:
     permission_type: custom
-id: node.field_event_date_and_time
-field_name: field_event_date_and_time
+id: node.field_training_links
+field_name: field_training_links
 entity_type: node
-type: daterange
-settings:
-  datetime_type: datetime
-module: datetime_range
+type: link
+settings: {  }
+module: link
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -24,6 +24,8 @@ permissions:
   - 'unflag add_to_schedule'
   - 'use text format basic_html'
   - 'view field_payment_info'
+  - 'view field_training_files'
+  - 'view field_training_links'
   - 'view own field_hearing_sponsors'
   - 'view own field_interested_drupal_jobs'
   - 'view own field_t_shirt_size'

--- a/config/user.role.sponsor.yml
+++ b/config/user.role.sponsor.yml
@@ -13,4 +13,5 @@ permissions:
   - 'edit own badcamp_sponsor content'
   - 'edit own job_posting content'
   - 'revert job_posting revisions'
+  - 'skip CAPTCHA'
   - 'view job_posting revisions'

--- a/config/user.role.trainer.yml
+++ b/config/user.role.trainer.yml
@@ -6,4 +6,18 @@ id: trainer
 label: Trainer
 weight: 3
 is_admin: null
-permissions: {  }
+permissions:
+  - 'access in-place editing'
+  - 'create field_training_files'
+  - 'create field_training_links'
+  - 'edit field_training_files'
+  - 'edit field_training_links'
+  - 'edit own field_training_files'
+  - 'edit own field_training_links'
+  - 'edit own training content'
+  - 'revert training revisions'
+  - 'skip CAPTCHA'
+  - 'view own field_training_files'
+  - 'view own field_training_links'
+  - 'view the administration theme'
+  - 'view training revisions'

--- a/web/themes/custom/badcamp2017/templates/field/field--file.html.twig
+++ b/web/themes/custom/badcamp2017/templates/field/field--file.html.twig
@@ -1,0 +1,80 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+set classes = [
+'field',
+'field--name-' ~ field_name|clean_class,
+'field--type-' ~ field_type|clean_class,
+'field--label-' ~ label_display,
+]
+%}
+{%
+set title_classes = [
+'field__label',
+label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+    <div class="field__items">
+      {% endif %}
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+      {% if multiple %}
+    </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/web/themes/custom/badcamp2017/templates/field/field--link.html.twig
+++ b/web/themes/custom/badcamp2017/templates/field/field--link.html.twig
@@ -1,0 +1,80 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+set classes = [
+'field',
+'field--name-' ~ field_name|clean_class,
+'field--type-' ~ field_type|clean_class,
+'field--label-' ~ label_display,
+]
+%}
+{%
+set title_classes = [
+'field__label',
+label_display == 'visually_hidden' ? 'visually-hidden',
+]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+    <div class="field__items">
+      {% endif %}
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+      {% if multiple %}
+    </div>
+    {% endif %}
+  </div>
+{% endif %}


### PR DESCRIPTION
…r trainer role to be able to edit the training they are an author of and these files. Also, permissions for authenticated users to get access to the files and links. Also needed to override the theming of these fields as they were being output inline because of the override in field.html.twig. This should be changed in the future because the override in the general field template is far too greedy and probably not necessary except in a single instance. Also sneaking in adding masquerade because with multiple roles starting to happen it could come in handy for debugging or at least identifying an issue. Also getting in allowing sponsors and trainers to skip the annoying captcha.
Trainer role could not actually edit their training before. Also, made it so they edit using the admin theme because the badcamp theme is preventing "Add Another" button from working correctly.  